### PR TITLE
Solved dependency error of Google API Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,13 @@
 		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
-			<version>1.23.0</version>
+                        <version>1.23.0</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>com.google.guava</groupId>
+                                <artifactId>guava-jdk5</artifactId>
+                            </exclusion>
+                        </exclusions>
 		</dependency>
 
 


### PR DESCRIPTION
when partners deployed the Report State dashboard locally, they may
encounter a 500 Internal Server Error after pressing the button even
the key & agentUserId are both correct. It's a dependency error of
Google API Client, which uses an older version of Guava and doesn't
contain a static method directExecutor().

Reference: https://github.com/google/google-api-java-client/issues/903#issuecomment-226118119