### PR TITLE
Remove javax.annotation for maven deployment

### DIFF
--- a/src/main/java/com/google/home/graph/v1/HomeGraphApiServiceGrpc.java
+++ b/src/main/java/com/google/home/graph/v1/HomeGraphApiServiceGrpc.java
@@ -23,9 +23,6 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * entities and their relationships in the home.
  * </pre>
  */
-@javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
-    comments = "Source: homegraph.proto")
 public final class HomeGraphApiServiceGrpc {
 
   private HomeGraphApiServiceGrpc() {}


### PR DESCRIPTION
This PR fixes the error of maven deployment.
(> mvn appengine:deploy)

## Deploy environment
```
java version "11" 2018-09-25
Java(TM) SE Runtime Environment 18.9 (build 11+28)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)
```

## Error(japanese language)
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/wroclau/Documents/nenv/smart-home-dashboard/src/main/java/com/google/home/graph/v1/HomeGraphApiServiceGrpc.java:[26,18] シンボルを見つけられません
  シンボル:   クラス Generated
  場所: パッケージ javax.annotation
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.489 s
[INFO] Finished at: 2018-10-24T14:47:06+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project dashboard: Compilation failure
[ERROR] /Users/wroclau/Documents/nenv/smart-home-dashboard/src/main/java/com/google/home/graph/v1/HomeGraphApiServiceGrpc.java:[26,18] シンボルを見つけられません
[ERROR]   シンボル:   クラス Generated
[ERROR]   場所: パッケージ javax.annotation
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```
